### PR TITLE
Convert print statement to function for Python3 compat

### DIFF
--- a/basecrm/configuration.py
+++ b/basecrm/configuration.py
@@ -30,7 +30,7 @@ class Configuration(object):
         self.verify_ssl = options['verify_ssl'] if 'verify_ssl' in options else True
 
         if self.verbose:
-            print "BaseCRM client configuration: " + str(self.__dict__)
+            print("BaseCRM client configuration: ") + str(self.__dict__)
 
     def validate(self):
         """Validates whether a configuration is valid.


### PR DESCRIPTION
While 2to3 catches when the package is installed in Python 2 or 3, this solves the issue that if you do a vanilla checkout and run `python setup.py develop` then `import basecrm` this one statement fails in Python 3.
